### PR TITLE
Bug: Calculating idle time

### DIFF
--- a/connection_pool/__init__.py
+++ b/connection_pool/__init__.py
@@ -45,9 +45,11 @@ class WrapperConnection(object):
         self.usage = self.last = self.created = 0
 
     def __enter__(self):
+        print("Entering wrapper")
         return self.connection
 
     def __exit__(self, *exc_info):
+        print("Exiting wrapper")
         self.pool.release(self)
 
 


### PR DESCRIPTION
The calculation of idle time is wrong. At the moment, the last used time is updated on `using` and the calculation is done on `__exit__`, which is wrong. Unless your processing time is greater than the set idle time (`(wrapped.last + self._idle) < time.time()`), it will always return false.

The idle time should be calculated on getting the connection pool. If the connection has been idle fo X sec, we destroy the current one and return a new one